### PR TITLE
feat: make payment function

### DIFF
--- a/contracts/account/src/base/errors.cairo
+++ b/contracts/account/src/base/errors.cairo
@@ -1,0 +1,5 @@
+pub mod AccountErrors {
+    pub const CANNOT_BE_ADDR_ZERO: felt252 = 'Address cannot be Zero';
+    pub const AMOUNT_CANNOT_BE_ZERO: felt252 = 'Amount cannot be Zero';
+    pub const CURRENCY_IS_REQUIRED: felt252 = 'Currency cannot be Zero';
+}

--- a/contracts/account/src/contract/account.cairo
+++ b/contracts/account/src/contract/account.cairo
@@ -3,7 +3,10 @@
 
 #[starknet::contract(account)]
 mod Account {
+    use core::num::traits::Zero;
     use account::interfaces::Iaccount::Iaccount;
+    use account::interfaces::ILiquidityBridge::{ILiquidityBridge, ILiquidityBridgeDispatcher};
+    use account::base::errors::AccountErrors;
     use openzeppelin::account::AccountComponent;
     use openzeppelin::account::extensions::SRC9Component;
     use openzeppelin::introspection::src5::SRC5Component;
@@ -13,7 +16,7 @@ mod Account {
         Map, StorageMapReadAccess, StorageMapWriteAccess, StoragePointerReadAccess,
         StoragePointerWriteAccess,
     };
-    use starknet::{ClassHash, ContractAddress, get_caller_address};
+    use starknet::{ClassHash, ContractAddress, get_caller_address, get_contract_address};
     use openzeppelin::token::erc20::interface::{IERC20Dispatcher, IERC20DispatcherTrait};
 
 
@@ -66,6 +69,7 @@ mod Account {
         #[flat]
         UpgradeableEvent: UpgradeableComponent::Event,
         TokenApproved: TokenApproved,
+        PaymentMade: PaymentMade
     }
 
     #[derive(Drop, starknet::Event)]
@@ -74,6 +78,15 @@ mod Account {
         pub symbol: felt252,
         pub token_address: ContractAddress,
         pub amount: u128,
+    }
+
+    #[derive(Drop, starknet::Event)]
+    pub struct PaymentMade {
+        pub from: ContractAddress,
+        pub to: ContractAddress,
+        pub currency: felt252,
+        pub amount: u128,
+        pub used_bridge: bool,
     }
 
     #[constructor]
@@ -109,13 +122,96 @@ mod Account {
                 .write((caller, currency), current_balance + amount.try_into().unwrap());
         }
 
+        fn make_payment(
+            ref self: ContractState,
+            recipient: ContractAddress,
+            currency: felt252,
+            amount: u128,
+            use_liquidity_bridge: bool,
+        ) -> bool {
+            self.account.assert_only_self();
+            let account_address = get_contract_address();
+            assert(!recipient.is_zero(), AccountErrors::CANNOT_BE_ADDR_ZERO);
+            assert(!amount.is_zero(), AccountErrors::AMOUNT_CANNOT_BE_ZERO);
+            assert(!currency.is_zero(), AccountErrors::CURRENCY_IS_REQUIRED);
+            let current_balance = self.fiat_balance.read((account_address, currency));
+
+            if current_balance >= amount {
+                self.fiat_balance.write((account_address, currency), current_balance - amount);
+                let recipient_balance = self.fiat_balance.read((recipient, currency));
+                self.fiat_balance.write((recipient, currency), recipient_balance + amount);
+                self
+                    .emit(
+                        PaymentMade {
+                            from: account_address,
+                            to: recipient,
+                            currency,
+                            amount: current_balance - amount,
+                            used_bridge: use_liquidity_bridge,
+                        },
+                    );
+
+                return true;
+            } else if use_liquidity_bridge && current_balance < amount {
+                // If the balance is insufficient, try to swap crypto to fiat using the liquidity
+                // bridge
+                let bridge = self.liquidity_bridge.read();
+                let bridge_dispatcher = ILiquidityBridgeDispatcher { contract_address: bridge };
+
+                let crypto_symbol = 'STRK';
+                assert(!crypto_symbol.is_zero(), AccountErrors::CURRENCY_IS_REQUIRED);
+
+                // The amount to swap will be the difference between the current balance and the
+                // amount
+                let amount_to_swap = amount - current_balance;
+                assert(amount_to_swap > 0, AccountErrors::AMOUNT_CANNOT_BE_ZERO);
+
+                // The swap_crypto_to_fiat will use the liquidity bridge to swap crypto to fiat
+                // It will use the account_address to see if the user has enough crypto to swap
+                // Deduct the amount from the token account after successful swap
+                // Credit user with the amount required to complete the payment
+                let success = bridge_dispatcher
+                    .swap_crypto_to_fiat(
+                        account_address, crypto_symbol, currency, amount_to_swap.into(),
+                    ); // the swap_crypto_to_fiat will use the liquidity bridge to swap crypto to fiat 
+
+                if success {
+                    // If the swap was successful, update the fiat balance
+                    let new_balance = self.get_fiat_balance(currency);
+                    assert(new_balance >= amount, 'Insufficient balance after swap');
+
+                    // Deduct the amount after successful swap
+                    self.fiat_balance.write((account_address, currency), new_balance - amount);
+
+                    // Credit recipient
+                    let recipient_balance = self.fiat_balance.read((recipient, currency));
+                    self.fiat_balance.write((recipient, currency), recipient_balance + amount);
+
+                    self
+                        .emit(
+                            PaymentMade {
+                                from: account_address,
+                                to: recipient,
+                                currency,
+                                amount,
+                                used_bridge: true,
+                            },
+                        );
+                    return true;
+                }
+            }
+            return false;
+        }
+
         fn get_balance(self: @ContractState) -> felt252 {
             let caller = get_caller_address();
             let currency = self.default_fiat_currency.read();
             self.fiat_balance.read((caller, currency)).into()
         }
 
-        fn initialize(ref self: ContractState, public_key: felt252, liquidity_bridge: ContractAddress) {
+        fn initialize(
+            ref self: ContractState, public_key: felt252, liquidity_bridge: ContractAddress
+        ) {
             assert(!self.initialized.read(), 'Already initialized');
             self.public_key.write(public_key);
             self.liquidity_bridge.write(liquidity_bridge);
@@ -125,23 +221,28 @@ mod Account {
         fn approve_token(ref self: ContractState, symbol: felt252, token_address: ContractAddress) {
             self.account.assert_only_self();
             assert(self.initialized.read(), 'Not initialized');
-            assert(self.approved_tokens.read(symbol) == 0.try_into().unwrap(), 'Token already approved');
+            assert(
+                self.approved_tokens.read(symbol) == 0.try_into().unwrap(), 'Token already approved'
+            );
             assert(token_address != 0.try_into().unwrap(), 'Token address cannot be 0');
 
             self.approved_tokens.write(symbol, token_address);
-            
+
             let bridge_address = self.liquidity_bridge.read();
-            
+
             let token_dispatcher = IERC20Dispatcher { contract_address: token_address };
-            
+
             token_dispatcher.approve(bridge_address, 10000000000000000000);
-            
-            self.emit(TokenApproved {
-                user: get_caller_address(),
-                symbol,
-                token_address,
-                amount: 10000000000000000000,
-            });
+
+            self
+                .emit(
+                    TokenApproved {
+                        user: get_caller_address(),
+                        symbol,
+                        token_address,
+                        amount: 10000000000000000000,
+                    }
+                );
         }
 
         fn get_liquidity_bridge(self: @ContractState) -> ContractAddress {

--- a/contracts/account/src/interfaces/ILiquidityBridge.cairo
+++ b/contracts/account/src/interfaces/ILiquidityBridge.cairo
@@ -1,0 +1,11 @@
+use starknet::ContractAddress;
+#[starknet::interface]
+pub trait ILiquidityBridge<TContractState> {
+    fn swap_crypto_to_fiat(
+        ref self: TContractState,
+        user: ContractAddress,
+        crypto_symbol: felt252,
+        fiat_currency: felt252,
+        fiat_amount: u256,
+    ) -> bool;
+}

--- a/contracts/account/src/interfaces/Iaccount.cairo
+++ b/contracts/account/src/interfaces/Iaccount.cairo
@@ -9,4 +9,11 @@ pub trait Iaccount<TContractState> {
     fn get_key_public(self: @TContractState) -> felt252;
     fn get_approved_token(self: @TContractState, symbol: felt252) -> ContractAddress;
     fn get_initialized_status(self: @TContractState) -> bool;
+    fn make_payment(
+        ref self: TContractState,
+        recipient: ContractAddress,
+        currency: felt252,
+        amount: u128,
+        use_liquidity_bridge: bool,
+    ) -> bool;
 }

--- a/contracts/account/src/lib.cairo
+++ b/contracts/account/src/lib.cairo
@@ -4,4 +4,10 @@ pub mod contract {
 
 pub mod interfaces {
     pub mod Iaccount;
+    pub mod ILiquidityBridge;
+}
+
+
+pub mod base {
+    pub mod errors;
 }

--- a/contracts/account/tests/test_account.cairo
+++ b/contracts/account/tests/test_account.cairo
@@ -1,6 +1,4 @@
-use account::interfaces::Iaccount::{
-    IaccountDispatcher, IaccountDispatcherTrait
-};
+use account::interfaces::Iaccount::{IaccountDispatcher, IaccountDispatcherTrait};
 use snforge_std::{
     ContractClassTrait, DeclareResultTrait, declare, start_cheat_caller_address,
     stop_cheat_caller_address,
@@ -49,7 +47,9 @@ fn test_approve_token() {
 
     let dispatcher = IaccountDispatcher { contract_address };
 
-    let token_address: ContractAddress = contract_address_const::<0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d>();
+    let token_address: ContractAddress = contract_address_const::<
+        0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d
+    >();
 
     start_cheat_caller_address(contract_address, contract_address);
 


### PR DESCRIPTION
# Feature: Implement `make_payment` Function in Cairo Contract

## Overview

This PR adds the `make_payment` function to enable fiat payments from users to recipients. When a user’s fiat balance is insufficient and `use_liquidity_bridge` is `true`, the function will attempt to use a liquidity bridge to convert crypto to fiat and complete the payment.

---

## Changes

- Added `make_payment` function with parameters:
  - `recipient: ContractAddress`
  - `currency: felt252`
  - `amount: u128`
  - `use_liquidity_bridge: bool`

- Validates that `recipient`, `currency`, and `amount` are not zero.

- Payment flow:
  - If sender’s fiat balance is enough, deduct and transfer the amount.
  - If balance is insufficient and `use_liquidity_bridge` is true:
    - Use `ILiquidityBridgeDispatcher` to swap crypto for fiat.
    - Retry payment if balance is sufficient after swap.

- Emits a `PaymentMade` event with details including whether the liquidity bridge was used.

- Returns `true` on successful payment, `false` otherwise.

---

## Event Definition

```cairo
#[derive(Drop, starknet::Event)]
pub struct PaymentMade {
    from: ContractAddress,
    to: ContractAddress,
    currency: felt252,
    amount: u128,
    used_bridge: bool,
}

Fix #4